### PR TITLE
[M3A1] Links e navegação SPA no NextJS

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function page404() {
+  return (
+    <h1>
+      Página não encontrada
+    </h1>
+  );
+}

--- a/pages/app/login/index.js
+++ b/pages/app/login/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function pageAppLogin() {
+  return (
+    <h1>
+      Página de Login
+    </h1>
+  );
+}

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function pageFAQ() {
+  return (
+    <h1>
+      Página de FAQ
+    </h1>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -39,7 +39,9 @@ export default function Home() {
         )}
       </Modal>
 
-      <Menu />
+      <Menu
+        onOpenModal={() => setModalState(true)}
+      />
 
       <Grid.Container>
         <Grid.Row>

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function pageSobre() {
+  return (
+    <h1>
+      Sobre
+    </h1>
+  );
+}

--- a/src/components/commons/Button/index.js
+++ b/src/components/commons/Button/index.js
@@ -1,8 +1,11 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
 import get from 'lodash/get';
+import PropTypes from 'prop-types';
 import { TextStyleVariants } from '../../foundation/Text';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
 import cssInline from '../../../theme/utils/cssInline';
+import Link from '../Link';
 
 const ButtonGhost = css`
     color: ${({ theme, variant }) => get(theme, `colors.${variant}.color`)};
@@ -14,7 +17,7 @@ const ButtonDefault = css`
     background-color: ${({ theme, variant }) => get(theme, `colors.${variant}.color`)};
 `;
 
-const Button = styled.button`
+const ButtonWrapper = styled.button`
     border: 0;
     cursor: pointer;
     padding: 12px 26px;
@@ -47,4 +50,23 @@ const Button = styled.button`
     `};
 `;
 
-export { Button as default };
+export default function Button({ href, ...props }) {
+  const isLink = Boolean(href);
+  const componentTag = isLink ? Link : 'button';
+  return (
+    <ButtonWrapper
+      as={componentTag}
+      href={href}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  );
+}
+
+Button.defaultProps = {
+  href: undefined,
+};
+
+Button.propTypes = {
+  href: PropTypes.string,
+};

--- a/src/components/commons/Link/index.js
+++ b/src/components/commons/Link/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import NextLink from 'next/link';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+
+const StyledLink = styled.a`
+  color: inherit;
+  ${({ theme, color }) => (color
+    ? `color: ${get(theme, `colors.${color}.color`)}`
+    : 'color: inherit;')};
+  text-decoration: none;
+  opacity: 1;
+  transition: opacity ${({ theme }) => theme.transition};
+  &:hover,
+  &:focus {
+    opacity: .5;
+  }
+`;
+
+export default function Link({ children, href, ...props }) {
+  return (
+    <NextLink
+      href={href}
+      passHref
+    >
+      <StyledLink
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+      >
+        {children}
+      </StyledLink>
+    </NextLink>
+  );
+}
+
+Link.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/commons/Menu/index.js
+++ b/src/components/commons/Menu/index.js
@@ -36,7 +36,7 @@ export default function Menu({ onOpenModal }) {
         ))}
       </MenuWrapper.CentralSide>
       <MenuWrapper.RightSide>
-        <Button ghost variant="secondary.main">
+        <Button ghost variant="secondary.main" href="/app/login">
           Entrar
         </Button>
         <Button variant="primary.main" onClick={onOpenModal}>

--- a/src/components/commons/Menu/index.js
+++ b/src/components/commons/Menu/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Logo from '../../../theme/Logo';
 import Text from '../../foundation/Text';
 import Button from '../Button';
@@ -19,7 +20,7 @@ const links = [
   },
 ];
 
-export default function Menu() {
+export default function Menu({ onOpenModal }) {
   return (
     <MenuWrapper>
       <MenuWrapper.LeftSide>
@@ -38,10 +39,14 @@ export default function Menu() {
         <Button ghost variant="secondary.main">
           Entrar
         </Button>
-        <Button variant="primary.main">
+        <Button variant="primary.main" onClick={onOpenModal}>
           Cadastrar
         </Button>
       </MenuWrapper.RightSide>
     </MenuWrapper>
   );
 }
+
+Menu.propTypes = {
+  onOpenModal: PropTypes.func.isRequired,
+};

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import cssInline from '../../../theme/utils/cssInline';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
+import Link from '../../commons/Link';
 
 const paragraph1 = css`
   ${({ theme }) => css`
@@ -51,12 +52,16 @@ const TextBase = styled.span`
 `;
 
 export default function Text({
-  tag, variant, children, ...props
+  tag, variant, children, href, ...props
 }) {
+  const typeTag = href ? Link : tag;
+  const propsHref = href ? { href } : '';
   return (
     <TextBase
-      as={tag}
+      as={typeTag}
       variant={variant}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...propsHref}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
@@ -69,10 +74,15 @@ Text.defaultProps = {
   tag: 'span',
   variant: 'paragraph1',
   children: null,
+  href: false,
 };
 
 Text.propTypes = {
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'p', 'li', 'a', 'span', 'input']),
   variant: PropTypes.oneOf(['title', 'paragraph1', 'smallestException']),
   children: PropTypes.node,
+  href: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
 };


### PR DESCRIPTION
Inclusão de navegação SinglePage, criação de páginas estáticas e ajuste nos componentes Text e Button.

**Ajustes extras:**
- Uso de operador ternário no componente Link, evitando duplicação do código TextBase.
- Mudei o padrão do props HREF para false