### PR TITLE
[M3A5] Gerando Páginas Dinamicamente com o NextJS

### DIFF
--- a/pages/faq/[slug].js
+++ b/pages/faq/[slug].js
@@ -1,0 +1,80 @@
+import React from 'react';
+import FAQQuestionScreen from '../../src/components/screens/FAQQuestionScreen';
+import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
+
+function FAQInternaScreen({ category, question }) {
+  return (
+    <FAQQuestionScreen
+      question={question}
+      category={category}
+    />
+  );
+}
+
+FAQInternaScreen.propTypes = FAQQuestionScreen.propTypes;
+
+export default websitePageHOC(FAQInternaScreen);
+
+export async function getStaticProps({ params }) {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
+    .then(async (respostaDoServer) => {
+      const resposta = await respostaDoServer.json();
+      return resposta.data;
+    });
+
+  const dadosDaPagina = faqCategories.reduce((valorAcumulado, faqCategory) => {
+    const foundQuestion = faqCategory.questions.find((question) => {
+      if (question.slug === params.slug) {
+        return true;
+      }
+      return false;
+    });
+
+    if (foundQuestion) {
+      return {
+        ...valorAcumulado,
+        category: faqCategory,
+        question: foundQuestion,
+      };
+    }
+
+    return valorAcumulado;
+  }, {});
+
+  return {
+    props: {
+      category: dadosDaPagina.category,
+      question: dadosDaPagina.question,
+      pageWrapperProps: {
+        seoProps: {
+          headTitle: dadosDaPagina.question.title,
+        },
+      },
+    },
+  };
+}
+
+export async function getStaticPaths() {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
+    .then(async (respostaDoServer) => {
+      const resposta = await respostaDoServer.json();
+      return resposta.data;
+    });
+
+  const paths = faqCategories.reduce((valorAcumulado, faqCategory) => {
+    const questionsPaths = faqCategory.questions.map((question) => {
+      const questionSlug = question.slug;
+      return { params: { slug: questionSlug } };
+    });
+
+    return [
+      ...valorAcumulado,
+      ...questionsPaths,
+    ];
+  }, []);
+
+  return {
+    paths,
+    fallback: false,
+  };
+}

--- a/src/components/foundation/Box/index.js
+++ b/src/components/foundation/Box/index.js
@@ -3,6 +3,7 @@ import cssInline from '../../../theme/utils/cssInline';
 
 const Box = styled.div`
     ${cssInline}
+    ${({ theme, borderRadiusTheme }) => borderRadiusTheme && `border-radius: ${theme.borderRadius}`};
 `;
 
 export { Box as default };

--- a/src/components/foundation/Grid/index.js
+++ b/src/components/foundation/Grid/index.js
@@ -24,6 +24,7 @@ const Container = styled.div`
             max-width: 1222px;
         `,
   })};
+  ${cssInline}
 `;
 
 const Row = styled.div`

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -79,7 +79,7 @@ Text.defaultProps = {
 
 Text.propTypes = {
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'p', 'li', 'a', 'span', 'input']),
-  variant: PropTypes.oneOf(['title', 'paragraph1', 'smallestException', 'subTitle']),
+  variant: PropTypes.oneOf(['title', 'paragraph1', 'paragraph2', 'smallestException', 'subTitle']),
   children: PropTypes.node,
   href: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/components/screens/FAQQuestionScreen/index.js
+++ b/src/components/screens/FAQQuestionScreen/index.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTheme } from 'styled-components';
+import Grid from '../../foundation/Grid';
+import Box from '../../foundation/Box';
+import Text from '../../foundation/Text';
+
+export default function FAQQuestionScreen({ category, question }) {
+  const theme = useTheme();
+
+  return (
+    <Grid.Container
+      cssinline={{
+        flex: '1',
+        marginTop: {
+          xs: '32px',
+          md: '80px',
+        },
+      }}
+    >
+      <Grid.Row
+        cssinline={{
+          flexDirection: {
+            xs: 'column-reverse',
+            md: 'row',
+          },
+        }}
+      >
+        <Grid.Col
+          cssinline={{
+            offset: { sm: 0, lg: 1 },
+          }}
+          col={{ xs: 12, md: 4, lg: 4 }}
+        >
+          <Text
+            variant="title"
+            color="tertiary.main"
+            cssinline={{
+              marginBottom: '25px',
+            }}
+          >
+            Artigos
+            <br />
+            Relacionados
+          </Text>
+          <Box
+            as="ul"
+            cssinline={{
+              listStyle: 'none',
+              padding: '24px 30px',
+              backgroundColor: theme.colors.borders.main.color,
+            }}
+            borderRadiusTheme
+          >
+            {category.questions.map((currentQuestion) => (
+              <Text
+                key={currentQuestion.slug}
+                as="li"
+                variant="paragraph2"
+                href={`/${currentQuestion.slug}`}
+                color="primary.main"
+                cssinline={{
+                  marginBottom: '16px',
+                }}
+
+              >
+                {currentQuestion.title}
+              </Text>
+            ))}
+          </Box>
+        </Grid.Col>
+
+        <Grid.Col
+          col={{ lg: 6 }}
+          cssinline={{
+            marginBottom: {
+              xs: '50px',
+              md: '0',
+            },
+          }}
+
+        >
+          <Text
+            variant="title"
+            color="tertiary.main"
+          >
+            {question.title}
+          </Text>
+          <Text
+            as="p"
+            variant="paragraph1"
+            color="tertiary.light"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: question.description }}
+          />
+        </Grid.Col>
+      </Grid.Row>
+    </Grid.Container>
+  );
+}
+
+FAQQuestionScreen.propTypes = {
+  category: PropTypes.shape({
+    title: PropTypes.string,
+    questions: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+    })),
+  }).isRequired,
+  question: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
+};

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -1,12 +1,21 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+
 import WebsitePageWrapper from '..';
 import WebsiteGlobalProvider from '../provider';
 
-export default function websitePageHOC(PageComponent, { pageWrapperProps }) {
+export default function websitePageHOC(
+  PageComponent,
+  { pageWrapperProps } = { pageWrapperProps: {} },
+) {
   return (props) => (
     <WebsiteGlobalProvider>
-      <WebsitePageWrapper {...pageWrapperProps}>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+      >
         <PageComponent {...props} />
       </WebsitePageWrapper>
     </WebsiteGlobalProvider>


### PR DESCRIPTION
Inclusão de páginas de conteúdo do FAQ dinamicamente.

**Ajustes extras:**
- Inclusão da opção 'paragraph2' como parâmetro na props.variant do componente Text